### PR TITLE
Update modal.css

### DIFF
--- a/css/modal.css
+++ b/css/modal.css
@@ -78,6 +78,7 @@
 	 right: 0;
 }
  .popup__close {
+	 border: none;
 	 position: absolute;
 	 right: -1.5rem;
 	 top: -1.5rem;


### PR DESCRIPTION
prevents the modal close button to inherit border-bottom from universal style default for a tags